### PR TITLE
Update site to emphasize personal ownership

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="NJtek.net offers cutting-edge AI tools, cryptocurrency mining solutions, IT consulting, and investment research software." />
+  <meta name="description" content="NJtek.net is David DiBenedetto's personal website offering AI tools, cryptocurrency mining solutions, IT consulting, and investment research software." />
   <meta name="keywords" content="AI tools, cryptocurrency mining, FPGA mining, ASIC mining, auto-swap crypto, NJtek, NJWeb Solutions, Heathwater, HostedOp, ThermoHash, localized LLM, investment research, open-source projects, IT consulting" />
   <meta name="author" content="David DiBenedetto" />
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />
@@ -139,6 +139,7 @@
   <div class="scrollable-container">
     <div class="logo-container"><img src="/njtek.svg" alt="NJtek Logo" onerror="this.src='fallback-logo.png'" /></div>
     <h1 class="animated-title">Welcome to NJtek.net! 🚀</h1>
+    <div class="explanation text-center">NJtek.net is David DiBenedetto's personal website and is not affiliated with any corporation or NJtek Inc.</div>
 
     <div class="btn-wrapper">
       <div class="icon-flow">₿₿₿</div>


### PR DESCRIPTION
## Summary
- clarify in meta description that NJtek.net is David DiBenedetto's personal site
- add note on page that NJtek.net is not NJtek Inc or any corporation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68878f85f678832dbf54a621ed4019d8